### PR TITLE
Make copy constructors private

### DIFF
--- a/Countdown/Models/LetterList.cs
+++ b/Countdown/Models/LetterList.cs
@@ -59,7 +59,7 @@ namespace Countdown.Models
         }
 
 
-        public LetterList(LetterList other) : base(new List<LetterTile>())
+        private LetterList(LetterList other) : base(new List<LetterTile>())
         {
             if (other is null)
                 throw new ArgumentNullException(nameof(other));
@@ -172,7 +172,7 @@ namespace Countdown.Models
         }
 
 
-        public LetterTile(LetterTile other)
+        private LetterTile(LetterTile other)
         {
             if (other is null)
                 throw new ArgumentNullException(nameof(other));


### PR DESCRIPTION
Convention suggests the copy constructors should be protected but the class is sealed so I left them public. Due to the lack of data validation this was wrong so I've changed them to private.