### PR TITLE
Delete wordlist.dat placeholder

### DIFF
--- a/Countdown/Resources/wordlist.dat
+++ b/Countdown/Resources/wordlist.dat
@@ -1,1 +1,0 @@
-placeholder


### PR DESCRIPTION
So that it can be added to gitignore. It's a file generated by the build using the WordListUtility project