### PR TITLE
Fix a list item deselection bug

### DIFF
--- a/Countdown/App.xaml
+++ b/Countdown/App.xaml
@@ -52,8 +52,13 @@
             <Setter Property="Stylus.IsFlicksEnabled" Value="False"/>
             <Setter Property="VerticalContentAlignment" Value="Center"/>
             <Setter Property="ScrollViewer.IsDeferredScrollingEnabled" Value="False"/>
-            <Setter Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="true"/>
-            
+            <Setter Property="ItemsPanel">
+                <Setter.Value>
+                    <ItemsPanelTemplate>
+                        <StackPanel/>  
+                    </ItemsPanelTemplate>
+                </Setter.Value>
+            </Setter>
             <Setter Property="Template">
                 <Setter.Value>
                     <ControlTemplate TargetType="{x:Type ListView}">
@@ -66,13 +71,9 @@
                             <Trigger Property="IsEnabled" Value="false">
                                 <Setter Property="Background" TargetName="Bd" Value="{DynamicResource {x:Static SystemColors.WindowBrushKey}}"/>
                             </Trigger>
-                            <MultiTrigger>
-                                <MultiTrigger.Conditions>
-                                    <Condition Property="IsGrouping" Value="true"/>
-                                    <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false"/>
-                                </MultiTrigger.Conditions>
+                            <Trigger Property="IsGrouping" Value="True">
                                 <Setter Property="ScrollViewer.CanContentScroll" Value="false"/>
-                            </MultiTrigger>
+                            </Trigger>
                         </ControlTemplate.Triggers>
                     </ControlTemplate>
                 </Setter.Value>

--- a/Countdown/ViewModels/LettersViewModel.cs
+++ b/Countdown/ViewModels/LettersViewModel.cs
@@ -506,6 +506,12 @@ namespace Countdown.ViewModels
             {
                 foreach (WordItem e in WordList)
                 {
+                    // Always expand any groups. This guarantees the wpf ui items with in the group
+                    // are created. If they don't exist it causes problems when items are deselected
+                    // by clicking in the list, the bound model list item will not be deselected.
+                    if (!e.IsExpanded)
+                        e.IsExpanded = true;
+
                     if (!e.IsSelected)
                         e.IsSelected = true;
                 }

--- a/Countdown/Views/LettersView.xaml
+++ b/Countdown/Views/LettersView.xaml
@@ -233,7 +233,7 @@
                 <Path Style="{StaticResource CrossTickStyle}"/>
             </StackPanel>
 
-            <local:ScrollListView x:Name="WordListView" Grid.Row="1" ScrollToItem ="{Binding ScrollToItem}" SelectionMode="Extended" ItemsSource="{Binding Source={StaticResource WordListGrouping}}" Style="{StaticResource CommonListViewStyle}" ItemContainerStyle="{StaticResource CommonListViewItemContainerStyle}" ContextMenu="{StaticResource CopyPasteGoToContextMenu}" VirtualizingPanel.IsVirtualizingWhenGrouping="True">
+            <local:ScrollListView x:Name="WordListView" Grid.Row="1" ScrollToItem ="{Binding ScrollToItem}" SelectionMode="Extended" ItemsSource="{Binding Source={StaticResource WordListGrouping}}" Style="{StaticResource CommonListViewStyle}" ItemContainerStyle="{StaticResource CommonListViewItemContainerStyle}" ContextMenu="{StaticResource CopyPasteGoToContextMenu}" >
                 <local:ScrollListView.View>
                     <GridView AllowsColumnReorder="false">
                         <GridView.ColumnHeaderContainerStyle>


### PR DESCRIPTION
Stop using virtualisation. The VirtualizingStackPanel caused problems with bound model item selection. When items where deselected in the list view, only the virtualized items were being deselected in the model. When the list was then subsequently scrolled the previously invisible items were still selected because they were bound to the model items.