### PR TITLE
fix a bug when reading lines from the buffer

### DIFF
--- a/Countdown/Models/WordDictionary.cs
+++ b/Countdown/Models/WordDictionary.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
 using System.Threading;
@@ -287,7 +288,7 @@ namespace Countdown.Models
                 return Span<byte>.Empty;
             }
 
-            private int SeekNextLine() => buffer.AsSpan(position).IndexOf(cLine_seperator);
+            private int SeekNextLine() => buffer.AsSpan(position, dataSize - position).IndexOf(cLine_seperator);
         }
     }
 }


### PR DESCRIPTION
Need to limit the span size to the size of data in the buffer which most likely won't be the buffer size after the last stream read (it would have probably resulted in one garbage word added to the dictionary).