### PR TITLE
Update work around for ScrollIntoView() problem

### DIFF
--- a/Countdown/Views/ScrollListView.cs
+++ b/Countdown/Views/ScrollListView.cs
@@ -1,13 +1,13 @@
 ﻿using System;
 using System.ComponentModel;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
+using System.Windows.Threading;
 
 namespace Countdown.Views
 {
-    class ScrollListView : ListView
+    internal class ScrollListView : ListView
     {
        
         public object ScrollToItem
@@ -35,29 +35,18 @@ namespace Countdown.Views
                 {
                     listView.SelectedItem = e.NewValue;
 
-                    // dastardly hack - wait until the items in the recently expanded group have 
-                    // been created before scrolling the item into view. (Or at least add it to
-                    // the queue after the create event has been, if that's whats happening. The
-                    // duration of the delay may be immaterial.)
-                    // 
-                    // This method is called when a bound property, a list item is updated. It's updated
-                    // immediately after the item's group has been expanded via another property bound to
-                    // the expander. The problem shows up when the item's group hasn't previously been
-                    // expanded and if it was expanded the item wouldn't then be visible without scrolling.
-                    // When I say visible that may mean outside the virtualizing bounds. The list view 
-                    // VirtualizationMode makes no difference, nor does using a simple StackPanel for the
-                    // items panel. Calling ScrollIntoView() directly worked in Net4.5
-#if false
-                    listView.ScrollIntoView(e.NewValue);
-#else
-                    Task t = new Task(async () =>
-                    {
-                        await Task.Delay(100);
-                        _ = listView.Dispatcher.BeginInvoke(new Action(() => listView.ScrollIntoView(e.NewValue)));
-                    });
+                    // Work around a bug that stops ScrollIntoView() working on Net5.0
+                    // It appears that the ItemContainerGenerator status has been set to
+                    // GeneratorStatus.ContainersGenerated too early for the ScrollIntoView()
+                    // method. See:
+                    //
+                    // https://referencesource.microsoft.com/#PresentationFramework/src/Framework/System/Windows/Controls/ListBox.cs,0e6481e67cd3cffc
+                    //
+                    // The code below would have been called by ScrollIntoView() if the 
+                    // ItemContainerGenerator indicated the expanded group hadn't been generated...
 
-                    t.Start();
-#endif
+                    _ = listView.Dispatcher.BeginInvoke(DispatcherPriority.Loaded,
+                                                        new Action(() => listView.ScrollIntoView(e.NewValue)));
                 }
             }
         }


### PR DESCRIPTION
After a bit of investigation it seems that the ItemsContainerGenerator status is causing the problem.