### PR TITLE
Add a delete option to the Conundrum list

### DIFF
--- a/Countdown/App.xaml
+++ b/Countdown/App.xaml
@@ -130,38 +130,22 @@
             </Setter>
         </Style>
 
+
+        <!-- this should probably be a user defined setting... -->
+        <System:String x:Key="UrlEncodedLink">https://www.merriam-webster.com/dictionary/{0}</System:String>
+
         <!-- common menu items for context menus -->
-        <MenuItem x:Key="CopyMenuItem" Command="{Binding ListCopyCommand}" Header="Copy" InputGestureText="Ctrl+C" x:Shared ="false">
+        <MenuItem x:Key="CopyMenuItem" Header="Copy" Command="{Binding ListCopyCommand}" InputGestureText="Ctrl+C" x:Shared ="false">
             <MenuItem.Icon>
                 <Image Source="/Resources/copy.png" />
             </MenuItem.Icon>
         </MenuItem>
 
-        <!-- standard context menu for numbers list -->
-        <ContextMenu x:Key="CopyPasteContextMenu">
-            <ContextMenu.InputBindings>
-                <KeyBinding Command="{Binding ListCopyCommand}" Modifiers="Control" Key="C" />
-            </ContextMenu.InputBindings>
-            <StaticResource ResourceKey="CopyMenuItem"/>
-        </ContextMenu>
-
-        <!-- this should probably be a user defined setting... -->
-        <System:String x:Key="UrlEncodedLink">https://www.merriam-webster.com/dictionary/{0}</System:String>
-
-        <!-- context menu for letters and conundrum list -->
-        <ContextMenu x:Key="CopyPasteGoToContextMenu">
-            <ContextMenu.InputBindings>
-                <KeyBinding Command="{Binding ListCopyCommand}" Modifiers="Control" Key="C" />
-                <KeyBinding CommandParameter="{StaticResource UrlEncodedLink}" Command="{Binding GoToDefinitionCommand}" Modifiers="Control" Key="L" />
-            </ContextMenu.InputBindings>
-            <StaticResource ResourceKey="CopyMenuItem"/>
-            <Separator />
-            <MenuItem Header="Look up definition..." CommandParameter="{StaticResource UrlEncodedLink}" Command="{Binding GoToDefinitionCommand}" InputGestureText="Ctrl+L" >
-                <MenuItem.Icon>
-                    <Image Source="/Resources/goto.png" />
-                </MenuItem.Icon>
-            </MenuItem>
-        </ContextMenu>
+        <MenuItem x:Key="LinkMenuItem" Header="Look up definition..." CommandParameter="{StaticResource UrlEncodedLink}" Command="{Binding GoToDefinitionCommand}" InputGestureText="Ctrl+L" x:Shared ="false" >
+            <MenuItem.Icon>
+                <Image Source="/Resources/goto.png" />
+            </MenuItem.Icon>
+        </MenuItem>
 
         <!-- generic button style -->
         <Style TargetType="{x:Type Button}">

--- a/Countdown/ViewModels/ConundrumViewModel.cs
+++ b/Countdown/ViewModels/ConundrumViewModel.cs
@@ -40,6 +40,7 @@ namespace Countdown.ViewModels
         public ICommand SolveCommand { get; }
         public ICommand ListCopyCommand { get; }
         public ICommand GoToDefinitionCommand { get; }
+        public ICommand ClearCommand { get; }
 
 
         public ConundrumViewModel(Model model, StopwatchController sc)
@@ -52,6 +53,7 @@ namespace Countdown.ViewModels
 
             ListCopyCommand = new RelayCommand(ExecuteCopy, CanCopy);
             GoToDefinitionCommand = new RelayCommand(ExecuteGoToDefinition, CanGoToDefinition);
+            ClearCommand = new RelayCommand(ExecuteClear, CanCopy);
         }
 
 
@@ -206,8 +208,8 @@ namespace Countdown.ViewModels
                     conundrum[index] = Model.Conundrum[index][0]; 
 
                 Solution = word;
-                SolutionList.Insert(0, new ConundrumItem(new string(conundrum), word));
-                ScrollToItem = SolutionList[0];
+                SolutionList.Add(new ConundrumItem(new string(conundrum), word));
+                ScrollToItem = SolutionList[^1];
             }
         }
 
@@ -217,7 +219,7 @@ namespace Countdown.ViewModels
             if (notLoadedYet)
                 return false;
 
-            return (Solution?[0] == space_char) && Model.Conundrum.Any(s => !string.IsNullOrEmpty(s)) && (Model.Solve() != null);
+            return (Solution[0] == space_char) && Model.Conundrum.Any(s => !string.IsNullOrEmpty(s)) && (Model.Solve() != null);
         }
 
    
@@ -245,10 +247,7 @@ namespace Countdown.ViewModels
         }
 
 
-        private bool CanCopy(object p)
-        {
-            return (SolutionList != null) && SolutionList.Any(e => e.IsSelected);
-        }
+        private bool CanCopy(object p) => SolutionList.Any(e => e.IsSelected);
     
         private void ExecuteGoToDefinition(object p)
         {
@@ -274,6 +273,15 @@ namespace Countdown.ViewModels
             }
         }
 
-        private bool CanGoToDefinition(object p) => SolutionList?.Count(e => e.IsSelected) is > 0 and < 11;
+        private bool CanGoToDefinition(object p) => SolutionList.Count(e => e.IsSelected) is > 0 and < 11;
+
+        private void ExecuteClear(object p)
+        {
+            for (int index = SolutionList.Count - 1; index >= 0; --index)
+            {
+                if (SolutionList[index].IsSelected)
+                    SolutionList.RemoveAt(index);
+            }
+        }
     }
 }

--- a/Countdown/Views/ConundrumView.xaml
+++ b/Countdown/Views/ConundrumView.xaml
@@ -45,9 +45,9 @@
         </DataTemplate>
 
         <DataTemplate x:Key="SolutionCellTemplateStyle">
-            <TextBlock Text="{Binding Solution}" HorizontalAlignment="Left" Padding="10,0,0,0"/>
+            <TextBlock Text="{Binding Solution}" HorizontalAlignment="Left" Padding="10,0,0,0" />
         </DataTemplate>
-        
+
     </UserControl.Resources>
 
     <DockPanel Margin="5" LastChildFill="True">
@@ -107,16 +107,34 @@
             </Grid>
         </Grid>
 
-        <ListView Margin="5" ItemsSource="{Binding SolutionList}" SelectionMode="Extended" local:ScrollTo.Item="{Binding ScrollToItem}" Style="{StaticResource CommonListViewStyle}" ItemContainerStyle="{StaticResource CommonListViewItemContainerStyle}" ContextMenu="{StaticResource CopyPasteGoToContextMenu}" UseLayoutRounding="True">
+        <ListView Margin="5" ItemsSource="{Binding SolutionList}" SelectionMode="Extended" local:ScrollTo.Item="{Binding ScrollToItem}" Style="{StaticResource CommonListViewStyle}" ItemContainerStyle="{StaticResource CommonListViewItemContainerStyle}" UseLayoutRounding="True">
             <ListView.View>
-                <GridView  AllowsColumnReorder="true" >
+                <GridView  AllowsColumnReorder="True" >
                     <GridViewColumn Header="Conundrum" Width="100" CellTemplate="{StaticResource ConundrumCellTemplateStyle}"/>
                     <GridViewColumn Header="Solution" Width="100" CellTemplate="{StaticResource SolutionCellTemplateStyle}"/>
                 </GridView>
             </ListView.View>
+            <ListView.ContextMenu>
+                <ContextMenu>
+                    <ContextMenu.InputBindings>
+                        <KeyBinding Command="{Binding ListCopyCommand}" Modifiers="Control" Key="C" />
+                        <KeyBinding CommandParameter="{StaticResource UrlEncodedLink}" Command="{Binding GoToDefinitionCommand}" Modifiers="Control" Key="L" />
+                    </ContextMenu.InputBindings>
+                    <StaticResource ResourceKey="CopyMenuItem"/>
+                    <Separator />
+                    <StaticResource ResourceKey="LinkMenuItem"/>
+                    <Separator />
+                    <MenuItem Header="Clear" Command="{Binding ClearCommand}" InputGestureText="DEL" >
+                        <MenuItem.Icon>
+                            <Path Data="M3,3 L13,13 M3,13 L13,3" Stroke="Black" StrokeThickness="1.5" Width="16" Height="16"/>
+                        </MenuItem.Icon>
+                    </MenuItem>
+                </ContextMenu>
+            </ListView.ContextMenu>
             <ListView.InputBindings>
                 <KeyBinding Command="{Binding ListCopyCommand}" Modifiers="Control" Key="C" />
                 <KeyBinding CommandParameter="{StaticResource UrlEncodedLink}" Command="{Binding GoToDefinitionCommand}" Modifiers="Control" Key="L" />
+                <KeyBinding Command="{Binding ClearCommand}" Key="Delete" />
             </ListView.InputBindings>
         </ListView>
     </DockPanel>

--- a/Countdown/Views/LettersView.xaml
+++ b/Countdown/Views/LettersView.xaml
@@ -233,7 +233,7 @@
                 <Path Style="{StaticResource CrossTickStyle}"/>
             </StackPanel>
 
-            <ListView x:Name="WordListView" Grid.Row="1" local:ScrollTo.Item ="{Binding ScrollToItem}" SelectionMode="Extended" ItemsSource="{Binding Source={StaticResource WordListGrouping}}" Style="{StaticResource CommonListViewStyle}" ItemContainerStyle="{StaticResource CommonListViewItemContainerStyle}" ContextMenu="{StaticResource CopyPasteGoToContextMenu}" >
+            <ListView x:Name="WordListView" Grid.Row="1" local:ScrollTo.Item ="{Binding ScrollToItem}" SelectionMode="Extended" ItemsSource="{Binding Source={StaticResource WordListGrouping}}" Style="{StaticResource CommonListViewStyle}" ItemContainerStyle="{StaticResource CommonListViewItemContainerStyle}">
                 <ListView.View>
                     <GridView AllowsColumnReorder="false">
                         <GridView.ColumnHeaderContainerStyle>
@@ -281,6 +281,17 @@
                         </GroupStyle.ContainerStyle>
                     </GroupStyle>
                 </ListView.GroupStyle>
+                <ListView.ContextMenu>
+                    <ContextMenu>
+                        <ContextMenu.InputBindings>
+                            <KeyBinding Command="{Binding ListCopyCommand}" Modifiers="Control" Key="C" />
+                            <KeyBinding CommandParameter="{StaticResource UrlEncodedLink}" Command="{Binding GoToDefinitionCommand}" Modifiers="Control" Key="L" />
+                        </ContextMenu.InputBindings>
+                        <StaticResource ResourceKey="CopyMenuItem"/>
+                        <Separator />
+                        <StaticResource ResourceKey="LinkMenuItem"/>
+                    </ContextMenu>
+                </ListView.ContextMenu>
                 <ListView.InputBindings>
                     <KeyBinding Command="{Binding ListCopyCommand}" Modifiers="Control" Key="C" />
                     <KeyBinding CommandParameter="{StaticResource UrlEncodedLink}" Command="{Binding GoToDefinitionCommand}" Modifiers="Control" Key="L" />

--- a/Countdown/Views/NumbersView.xaml
+++ b/Countdown/Views/NumbersView.xaml
@@ -74,7 +74,7 @@
             </Grid>
         </Grid>
 
-        <ListView Margin="5" ItemsSource="{Binding EquationList}" SelectionMode="Extended" Style="{StaticResource CommonListViewStyle}" ItemContainerStyle="{StaticResource CommonListViewItemContainerStyle}" ContextMenu="{StaticResource CopyPasteContextMenu}" UseLayoutRounding="True">
+        <ListView Margin="5" ItemsSource="{Binding EquationList}" SelectionMode="Extended" Style="{StaticResource CommonListViewStyle}" ItemContainerStyle="{StaticResource CommonListViewItemContainerStyle}" UseLayoutRounding="True">
             <ListView.View>
                 <GridView AllowsColumnReorder="false" >
                     <GridView.ColumnHeaderContainerStyle>
@@ -85,10 +85,17 @@
                     <GridViewColumn Width="220" DisplayMemberBinding="{Binding}"/>
                 </GridView>
             </ListView.View>
+            <ListView.ContextMenu>
+                <ContextMenu>
+                    <ContextMenu.InputBindings>
+                        <KeyBinding Command="{Binding ListCopyCommand}" Modifiers="Control" Key="C" />
+                    </ContextMenu.InputBindings>
+                    <StaticResource ResourceKey="CopyMenuItem"/>
+                </ContextMenu>
+            </ListView.ContextMenu>
             <ListView.InputBindings>
                 <KeyBinding Command="{Binding ListCopyCommand}" Modifiers="Control" Key="C" />
             </ListView.InputBindings>
         </ListView>
-       
     </DockPanel>
 </UserControl>


### PR DESCRIPTION
Now the context menus for each list are different move them into their associated list view. Only keep the shared parts in App.xml.
Go back to adding the latest solution to the end of the list. After using the feature it was a bit strange adding it to the start.