### PR TITLE
Update Combination and Permutation enumerators

### DIFF
--- a/Countdown/Models/Combinations.cs
+++ b/Countdown/Models/Combinations.cs
@@ -20,7 +20,7 @@ namespace Countdown.Models
     ///        
     /// </summary>
     /// <typeparam name="T"></typeparam>
-    internal sealed class Combinations<T> : IEnumerable<List<T>> 
+    internal sealed class Combinations<T> : IEnumerable<T[]> 
     {
         /// <summary>
         /// copy of the source 
@@ -104,7 +104,7 @@ namespace Countdown.Models
         /// Gets the generic enumerator for the combinations.
         /// </summary>
         /// <returns></returns>
-        public IEnumerator<List<T>> GetEnumerator()
+        public IEnumerator<T[]> GetEnumerator()
         {
             return new CombinationEnumerator(this);
         }
@@ -116,7 +116,7 @@ namespace Countdown.Models
         /// The enumerator for the combinations. Each time MoveNext()
         /// is called a new combination generated on demand.
         /// </summary>
-        private struct CombinationEnumerator : IEnumerator<List<T>>
+        private struct CombinationEnumerator : IEnumerator<T[]>
         {
             /// <summary>
             /// the source collection
@@ -216,14 +216,17 @@ namespace Countdown.Models
             /// <summary>
             /// IEnumerator<T>.Current interface implementation. 
             /// </summary>
-            public List<T> Current
+            public T[] Current
             {
                 get
                 {
                     if (setUpFirstItem)
                         throw new InvalidOperationException("Enumerator state is invalid");
 
-                    return new List<T>(current);
+                    T[] copy = new T[k];
+                    current.AsSpan().CopyTo(copy);
+
+                    return copy;
                 }
             }
 

--- a/Countdown/Models/Model.cs
+++ b/Countdown/Models/Model.cs
@@ -103,7 +103,7 @@ namespace Countdown.Models
             {
                 Combinations<int> combinations = new Combinations<int>(tiles, k);
 
-                foreach (List<int> combination in combinations)
+                foreach (int[] combination in combinations)
                 {
                     Permutations<int> permutations = new Permutations<int>(combination);
 

--- a/Countdown/Models/Permutations.cs
+++ b/Countdown/Models/Permutations.cs
@@ -8,7 +8,7 @@ namespace Countdown.Models
     /// <summary>
     /// Generates all permutations for a collection of objects. 
     /// </summary>
-    internal sealed class Permutations<T> : IEnumerable<List<T>> 
+    internal sealed class Permutations<T> : IEnumerable<T[]> 
     {
         /// <summary>
         /// store for the source 
@@ -58,7 +58,7 @@ namespace Countdown.Models
         /// Gets the generic enumerator for the permutations.
         /// </summary>
         /// <returns></returns>
-        public IEnumerator<List<T>> GetEnumerator()
+        public IEnumerator<T[]> GetEnumerator()
         {
             return new PermutationEnumerator(this);
         }
@@ -70,7 +70,7 @@ namespace Countdown.Models
         /// The enumerator for the permutations. Each time MoveNext()
         /// is called a new permutation generated.
         /// </summary>
-        private struct PermutationEnumerator : IEnumerator<List<T>>
+        private struct PermutationEnumerator : IEnumerator<T[]>
         {
             /// <summary>
             /// the current permutation
@@ -136,14 +136,17 @@ namespace Countdown.Models
             /// <summary>
             /// IEnumerator<T>.Current interface implementation. 
             /// </summary>
-            public List<T> Current
+            public T[] Current
             {
                 get
                 {
                     if (setUpFirstItem)
                         throw new InvalidOperationException("Enumerator state is invalid");
 
-                    return new List<T>(current);
+                    T[] copy = new T[current.Length];
+                    current.AsSpan().CopyTo(copy);
+
+                    return copy;
                 }
             }
 

--- a/Countdown/Models/SolvingEngine.cs
+++ b/Countdown/Models/SolvingEngine.cs
@@ -127,7 +127,7 @@ namespace Countdown.Models
         /// <param name="permutation">the current tile permutation</param>
         /// <param name="permutationIndex">position in the permutation</param>
         /// <param name="depth">recursion depth</param>
-        private void SolveRecursive(int stackHead, List<int> mapEntry, int mapIndex, List<int> permutation, int permutationIndex, int depth)
+        private void SolveRecursive(int stackHead, List<int> mapEntry, int mapIndex, int[] permutation, int permutationIndex, int depth)
         {
             const int cInvalidResult = 0;
 
@@ -245,13 +245,13 @@ namespace Countdown.Models
         /// <param name="mapEntry"></param>
         /// <param name="permutation"></param>
         /// <returns></returns>
-        private string ConvertToString(List<int> mapEntry, List<int> permutation)
+        private string ConvertToString(List<int> mapEntry, int[] permutation)
         {
             int mapIndex = 0;
             int operatorCount = 0;
             int permutationCount = 0;
 
-            string[] stack = new string[permutation.Count];
+            string[] stack = new string[permutation.Length];
             int stackHead = -1;
 
             do
@@ -284,7 +284,7 @@ namespace Countdown.Models
         /// <summary>
         /// starts the solving engine for the given permutation 
         /// </summary>
-        public void Solve(List<int> permutation)
+        public void Solve(int[] permutation)
         {
             foreach (List<int> mapEntry in map)
                 SolveRecursive(-1, mapEntry, 0, permutation, 0, 0);

--- a/Countdown/Models/WordDictionary.cs
+++ b/Countdown/Models/WordDictionary.cs
@@ -49,7 +49,7 @@ namespace Countdown.Models
 
             for (int k = letters.Length; k >= cMinLetters; --k)
             {
-                foreach (List<char> chars in new Combinations<char>(letters, k))
+                foreach (char[] chars in new Combinations<char>(letters, k))
                 {
                     AddDictionaryWordsToList(chars, otherWords, results);
 
@@ -64,9 +64,9 @@ namespace Countdown.Models
 
 
 
-        private static void AddDictionaryWordsToList(List<char> keyChars, Dictionary<string, byte[]> dictionary, List<WordItem> list)
+        private static void AddDictionaryWordsToList(char[] keyChars, Dictionary<string, byte[]> dictionary, List<WordItem> list)
         {
-            string key = new string(keyChars.ToArray());
+            string key = new string(keyChars);
 
             if (dictionary.TryGetValue(key, out byte[] data))
             {

--- a/UnitTests/CombinationTests.cs
+++ b/UnitTests/CombinationTests.cs
@@ -26,8 +26,8 @@ namespace Countdown.UnitTests
 
             for (int k = 1; k <= source.Count(); ++k)
             {
-                var list = new List<List<T>>(new Combinations<T>(source, k, comparer));
-                List<List<T>> altList = AltComb.Get(source, k, comparer);
+                var list = new List<T[]>(new Combinations<T>(source, k, comparer));
+                List<T[]> altList = AltComb.Get(source, k, comparer);
 
                 if (uniqueSource)
                     Assert.AreEqual(Utils.CombinationSize(source.Count(), k), list.Count) ;
@@ -89,9 +89,9 @@ namespace Countdown.UnitTests
         {
             int[] source = { 864 };
 
-            var list = new List<List<int>>(new Combinations<int>(source, 1));
+            var list = new List<int[]>(new Combinations<int>(source, 1));
 
-            if ((list.Count != 1) || (list[0].Count != 1) || (list[0][0] != source[0]))
+            if ((list.Count != 1) || (list[0].Length != 1) || (list[0][0] != source[0]))
                 Assert.Fail();
         }
 
@@ -113,7 +113,7 @@ namespace Countdown.UnitTests
 
             // k == 0 is a valid input condition. The enumerator should 
             // return nothing
-            foreach (List<int> o in c)
+            foreach (int[] o in c)
             {
                 Assert.Fail();
             }
@@ -137,10 +137,10 @@ namespace Countdown.UnitTests
             int[] source = { 1, 3, 2, 4 };
             Combinations<int> c = new Combinations<int>(source, 2);
 
-            IEnumerator<List<int>> e = c.GetEnumerator();
+            IEnumerator<int[]> e = c.GetEnumerator();
 
             // move next has not been called yet
-            List<int> current = e.Current;
+            _ = e.Current;
         }
         
 
@@ -152,7 +152,7 @@ namespace Countdown.UnitTests
             int[] source = { 1, 3, 2, 4 };
             Combinations<int> c = new Combinations<int>(source, 2);
 
-            IEnumerator<List<int>> e = c.GetEnumerator();
+            IEnumerator<int[]> e = c.GetEnumerator();
 
             e.MoveNext();
             e.MoveNext();
@@ -160,7 +160,7 @@ namespace Countdown.UnitTests
             e.Reset();
           
             // move next has not been called yet
-            List<int> current = e.Current;
+            _ = e.Current;
         }
 
 
@@ -173,12 +173,12 @@ namespace Countdown.UnitTests
             int[] source = { 1, 3, 2, 4 };
             Combinations<int> c = new Combinations<int>(source, 2);
 
-            IEnumerator<List<int>> e = c.GetEnumerator();
+            IEnumerator<int[]> e = c.GetEnumerator();
 
             while (e.MoveNext()) ;
 
             // end of the enumeration has been reached
-            List<int> current = e.Current;
+            _ = e.Current;
         }
 
         
@@ -236,10 +236,10 @@ namespace Countdown.UnitTests
             int[] source = { 1, 3, 2, 4 };
             Combinations<int> c = new Combinations<int>(source, 2);
 
-            IEnumerator<List<int>> e = c.GetEnumerator();
+            IEnumerator<int[]> e = c.GetEnumerator();
 
             e.MoveNext();
-            List<int> c1 = e.Current;
+            int[] c1 = e.Current;
             e.MoveNext();
 
             e.Reset();
@@ -255,8 +255,8 @@ namespace Countdown.UnitTests
             int[] source = { 1, 3, 2, 4 };
 
             Combinations<int> c1 = new Combinations<int>(source, 2);
-            List<List<int>> c1list = new List<List<int>>(c1);
-            List<List<int>> c2list = new List<List<int>>(c1);
+            List<int[]> c1list = new List<int[]>(c1);
+            List<int[]> c2list = new List<int[]>(c1);
 
             Assert.IsTrue(Utils.IsEqual(c1list, c2list));
         }

--- a/UnitTests/PermutationTests.cs
+++ b/UnitTests/PermutationTests.cs
@@ -19,9 +19,9 @@ namespace Countdown.UnitTests
 
         public void TestPermutations<T>(IEnumerable<T> source, IComparer<T> comparer = null) 
         {
-            var list = new List<List<T>>(new Permutations<T>(source, comparer));
+            var list = new List<T[]>(new Permutations<T>(source, comparer));
 
-            List<List<T>> altList = AltPerm.Get(source, comparer);
+            List<T[]> altList = AltPerm.Get(source, comparer);
 
             Assert.AreEqual(Utils.PermutaionSize(source), list.Count);
             Assert.IsTrue(Utils.IsEqual(list, altList, comparer));
@@ -51,10 +51,10 @@ namespace Countdown.UnitTests
             int[] source = { 1, 3, 2, 4 };
             Permutations<int> p = new Permutations<int>(source);
 
-            IEnumerator<List<int>> e = p.GetEnumerator();
+            IEnumerator<int[]> e = p.GetEnumerator();
 
             // move next has not been called yet
-            List<int> current = e.Current;
+            _ = e.Current;
         }
 
 
@@ -66,7 +66,7 @@ namespace Countdown.UnitTests
             int[] source = { 1, 3, 2, 4 };
             Permutations<int> p = new Permutations<int>(source);
 
-            IEnumerator<List<int>> e = p.GetEnumerator();
+            IEnumerator<int[]> e = p.GetEnumerator();
 
             e.MoveNext();
             e.MoveNext();
@@ -74,7 +74,7 @@ namespace Countdown.UnitTests
             e.Reset();
 
             // move next has not been called yet
-            List<int> current = e.Current;
+            _ = e.Current;
         }
 
 
@@ -87,12 +87,12 @@ namespace Countdown.UnitTests
             int[] source = { 1, 3, 2, 4 };
             Permutations<int> p = new Permutations<int>(source);
 
-            IEnumerator<List<int>> e = p.GetEnumerator();
+            IEnumerator<int[]> e = p.GetEnumerator();
 
             while (e.MoveNext()) ;
 
             // end of the enumeration has been reached
-            List<int> current = e.Current;
+            _ = e.Current;
         }
 
        
@@ -152,10 +152,10 @@ namespace Countdown.UnitTests
             int[] source = { 1, 3, 2, 4 };
             Permutations<int> p = new Permutations<int>(source);
 
-            IEnumerator<List<int>> e = p.GetEnumerator();
+            IEnumerator<int[]> e = p.GetEnumerator();
 
             e.MoveNext();
-            List<int> c1 = e.Current;
+            int[] c1 = e.Current;
             e.MoveNext();
 
             e.Reset();
@@ -189,9 +189,9 @@ namespace Countdown.UnitTests
         public void Source_Single()
         {
             int[] source = { 367 };
-            var list = new List<List<int>>(new Permutations<int>(source));
+            var list = new List<int[]>(new Permutations<int>(source));
 
-            if ((list.Count != 1) || (list[0].Count != 1) || (list[0][0] != source[0]))
+            if ((list.Count != 1) || (list[0].Length != 1) || (list[0][0] != source[0]))
                 Assert.Fail();
         }
 
@@ -204,8 +204,8 @@ namespace Countdown.UnitTests
             int[] source = { 1, 3, 2 };
             Permutations<int> p1 = new Permutations<int>(source);
 
-            List<List<int>> p1list = new List<List<int>>(p1);
-            List<List<int>> p2list = new List<List<int>>(p1);
+            List<int[]> p1list = new(p1);
+            List<int[]> p2list = new(p1);
 
             Assert.IsTrue(Utils.IsEqual(p1list, p2list));
         }

--- a/UnitTests/Utils.cs
+++ b/UnitTests/Utils.cs
@@ -84,7 +84,7 @@ namespace Countdown.UnitTests
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="list"></param>
-        internal static void RemoveDuplicates<T>(List<List<T>> list, IComparer<T> comparer = null)
+        internal static void RemoveDuplicates<T>(List<T[]> list, IComparer<T> comparer = null)
         {
             if (list != null)
             {
@@ -110,11 +110,11 @@ namespace Countdown.UnitTests
 
         internal static void TestComparers()
         {
-            List<int> l0 = null;
-            List<int> l1 = new List<int> { 0, 2, 3 };
-            List<int> l2 = new List<int> { 0, 2, 3 };
-            List<int> l3 = new List<int> { 1, 2, 4 };
-            List<int> l4 = new List<int> { 1, 2 };
+            int[] l0 = null;
+            int[] l1 = new int[] { 0, 2, 3 };
+            int[] l2 = new int[] { 0, 2, 3 };
+            int[] l3 = new int[] { 1, 2, 4 };
+            int[] l4 = new int[] { 1, 2 };
 
             Assert.IsTrue(Compare(l0, l0) == 0);    // nulls
             Assert.IsTrue(Compare(l1, l0) > 0);
@@ -129,13 +129,13 @@ namespace Countdown.UnitTests
             Assert.IsTrue(Compare(l1, l4) > 0);     // lengths
             Assert.IsTrue(Compare(l4, l1) < 0);
 
-            List<List<int>> ll0 = null;
-            List<List<int>> lr0 = null;
+            List<int[]> ll0 = null;
+            List<int[]> lr0 = null;
 
-            List<List<int>> ll1 = new List<List<int>> { l1, l1 };
-            List<List<int>> ll2 = new List<List<int>> { l2, l2 };
-            List<List<int>> ll3 = new List<List<int>> { l1, l3 };
-            List<List<int>> ll4 = new List<List<int>> { l1 };
+            List<int[]> ll1 = new List<int[]> { l1, l1 };
+            List<int[]> ll2 = new List<int[]> { l2, l2 };
+            List<int[]> ll3 = new List<int[]> { l1, l3 };
+            List<int[]> ll4 = new List<int[]> { l1 };
 
             Assert.IsTrue(Compare(lr0, ll0) == 0);  // nulls
             Assert.IsTrue(Compare(ll1, ll0) > 0);
@@ -162,13 +162,13 @@ namespace Countdown.UnitTests
 
 
         /// <summary>
-        /// Simplistic method to compare two ILists
+        /// Simplistic method to compare two arrays
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="left"></param>
         /// <param name="right"></param>
         /// <returns></returns>
-        internal static int Compare<T>(IList<T> left, IList<T> right, IComparer<T> comparer = null)
+        internal static int Compare<T>(T[] left, T[] right, IComparer<T> comparer = null)
         {
             if (ReferenceEquals(left, right))
                 return 0;
@@ -179,13 +179,13 @@ namespace Countdown.UnitTests
             if (right is null)
                 return 1;
 
-            if (left.Count != right.Count)
-                return (left.Count < right.Count) ? -1 : 1;
+            if (left.Length != right.Length)
+                return (left.Length < right.Length) ? -1 : 1;
 
             // null friendly comparer
             IComparer<T> c = comparer ?? Comparer<T>.Default;
 
-            for (int index = 0; index < left.Count; index++)
+            for (int index = 0; index < left.Length; index++)
             {
                 int cr = c.Compare(left[index], right[index]);
 
@@ -200,7 +200,7 @@ namespace Countdown.UnitTests
 
 
 
-        internal static int Compare<T>(List<List<T>> left, List<List<T>> right, IComparer<T> comparer = null)
+        internal static int Compare<T>(List<T[]> left, List<T[]> right, IComparer<T> comparer = null)
         {
             if (ReferenceEquals(left, right))
                 return 0;
@@ -226,13 +226,13 @@ namespace Countdown.UnitTests
         }
 
 
-        internal static bool IsEqual<T>(List<List<T>> left, List<List<T>> right, IComparer<T> comparer = null)
+        internal static bool IsEqual<T>(List<T[]> left, List<T[]> right, IComparer<T> comparer = null)
         {
             return Compare(left, right, comparer) == 0;
         }
 
 
-        internal static bool IsEqual<T>(IList<T> left, IList<T> right, IComparer<T> comparer = null)
+        internal static bool IsEqual<T>(T[] left, T[] right, IComparer<T> comparer = null)
         {
             return Compare(left, right, comparer) == 0;
         }
@@ -240,16 +240,16 @@ namespace Countdown.UnitTests
 
 
 
-    internal class ListComparerClass<T> : IComparer<IList<T>> 
+    internal class ArrayComparerClass<T> : IComparer<T[]> 
     {
         private readonly IComparer<T> comparer;
 
-        public ListComparerClass(IComparer<T> c)
+        public ArrayComparerClass(IComparer<T> c)
         {
             comparer = c;
         }
 
-        public int Compare(IList<T> left, IList<T> right)
+        public int Compare(T[] left, T[] right)
         {
             return Utils.Compare<T>(left, right, comparer);
         }
@@ -331,7 +331,7 @@ namespace Countdown.UnitTests
     internal static class AltPerm
     {
 
-        public static List<List<T>> Get<T>(IEnumerable<T> source, IComparer<T> comparer = null) 
+        public static List<T[]> Get<T>(IEnumerable<T> source, IComparer<T> comparer = null) 
         {
             if (source is null)
                 throw new ArgumentNullException(nameof(source));
@@ -339,7 +339,7 @@ namespace Countdown.UnitTests
             if (source.Count() == 0)
                 throw new ArgumentOutOfRangeException(nameof(source));
 
-            List<List<T>> result = new List<List<T>>();
+            List<T[]> result = new List<T[]>();
 
             T[] input = source.ToArray();
             Array.Sort(input, comparer);
@@ -347,7 +347,7 @@ namespace Countdown.UnitTests
             Permute(input, 0, input.Length - 1, result);
 
             // convert to lexicographical and remove duplicates 
-            result.Sort(new ListComparerClass<T>(comparer));
+            result.Sort(new ArrayComparerClass<T>(comparer));
 
             if (HasDuplicates(input))
                 Utils.RemoveDuplicates(result, comparer);
@@ -367,11 +367,13 @@ namespace Countdown.UnitTests
             b = tmp;
         }
 
-        private static void Permute<T>(T[] source, int recursionDepth, int maxDepth, List<List<T>> result)
+        private static void Permute<T>(T[] source, int recursionDepth, int maxDepth, List<T[]> result)
         {
             if (recursionDepth == maxDepth)
             {
-                result.Add(new List<T>(source));
+                T[] copy = new T[source.Length];
+                source.AsSpan().CopyTo(copy);
+                result.Add(copy);
                 return;
             }
 
@@ -395,7 +397,7 @@ namespace Countdown.UnitTests
     internal static class AltComb
     {
 
-        public static List<List<T>> Get<T>(IEnumerable<T> source, int k, IComparer<T> comparer = null) 
+        public static List<T[]> Get<T>(IEnumerable<T> source, int k, IComparer<T> comparer = null) 
         {
             if (source is null)
                 throw new ArgumentNullException(nameof(source));
@@ -409,10 +411,10 @@ namespace Countdown.UnitTests
             T[] input = source.ToArray();
             Array.Sort(input, comparer);
 
-            List<List<T>> result = GetCombinations(input, k);
+            List<T[]> result = GetCombinations(input, k);
 
             // convert to lexicographical and remove duplicates
-            result.Sort(new ListComparerClass<T>(comparer));
+            result.Sort(new ArrayComparerClass<T>(comparer));
 
             if (HasDuplicates(input))
                 Utils.RemoveDuplicates(result, comparer);
@@ -427,12 +429,12 @@ namespace Countdown.UnitTests
         }
 
 
-        private static List<List<T>> GetCombinations<T>(T[] source, int k)
+        private static List<T[]> GetCombinations<T>(T[] source, int k)
         {
-            List<List<T>> listOfLists = new List<List<T>>();
+            List<T[]> results = new List<T[]>();
 
             if (k == 0)
-                return listOfLists;
+                return results;
 
             int nonEmptyCombinations = (int)Math.Pow(2, source.Length) - 1;
 
@@ -447,10 +449,10 @@ namespace Countdown.UnitTests
                 }
 
                 if (thisCombination.Count == k)
-                    listOfLists.Add(thisCombination);
+                    results.Add(thisCombination.ToArray());
             }
 
-            return listOfLists;
+            return results;
         }
     }
 }


### PR DESCRIPTION
Change them to return arrays rather than lists. It improves the speed by a third, presumably because duplicating arrays is quicker than lists. It doesn't make a big difference to the solving time though.