### PR TITLE
Avoid resizing the solutions list while holding a lock

### DIFF
--- a/Countdown/Models/Model.cs
+++ b/Countdown/Models/Model.cs
@@ -121,6 +121,8 @@ namespace Countdown.Models
                 }
             }
 
+            results.AggregateResults();
+
             stopWatch.Stop();
             results.Elapsed = stopWatch.Elapsed;
 


### PR DESCRIPTION
Instead of copying each solver list contents, keep a reference to the lists and then copy them later when the parallel tasks have completed. Not pretty but list resizing is relatively slow.