### PR TITLE
Small optimization reading the word list

### DIFF
--- a/Countdown/Models/WordDictionary.cs
+++ b/Countdown/Models/WordDictionary.cs
@@ -267,14 +267,14 @@ namespace Countdown.Models
                         dataSize += bytesRead;
                     }
 
-                    position = 0;
+                    position = sizeLeft;
+
                     length = SeekNextLine();
 
-                    if (length > 0)  // its not the end of the stream, it shouldn't be
-                    {
-                        position += length + 1;
-                        return span.Slice(0, length);
-                    }
+                    Debug.Assert(length >= 0); // its not the end of the stream, it shouldn't be
+
+                    position += length + 1;
+                    return span.Slice(0, sizeLeft + length);
                 }
 
                 return Span<byte>.Empty;


### PR DESCRIPTION
If a partial line is moved to the front of the buffer before the buffer is refilled, there is no need to scan that part of the buffer again for a line seperator.