### PR TITLE
Tidy up the Stopwatch code

### DIFF
--- a/Countdown/ViewModels/StopwatchController.cs
+++ b/Countdown/ViewModels/StopwatchController.cs
@@ -9,7 +9,7 @@ namespace Countdown.ViewModels
     {
         private const long cForwardDurationTicks = 30 * TimeSpan.TicksPerSecond;
         private const long cRewindDurationTicks = 1 * TimeSpan.TicksPerSecond;
-        private const int cUpdateRateMilliseconds = 25;
+        private const int cUpdateRateMilliseconds = 5;
 
         public enum StopwatchStateEnum { AtStart, Running, Stopped, Rewinding }
 
@@ -25,19 +25,24 @@ namespace Countdown.ViewModels
         public ICommand StartStopTimerCommand { get; }
 
 
+        public StopwatchController()
+        {
+            StartStopTimerCommand = new RelayCommand(ExecuteTimer);
+            _cts = new CancellationTokenSource();
+        }
 
-        // the current clock time in system ticks 
+        // the elapsed time in system ticks 
         public long Ticks
         {
             get { return _ticks; }
-            set { HandlePropertyChanged(ref _ticks, value); }
+            private set { HandlePropertyChanged(ref _ticks, value); }
         }
 
 
         public StopwatchStateEnum StopwatchState
         {
             get { return _stopwatchState; }
-            set { HandlePropertyChanged(ref _stopwatchState, value); }
+            private set { HandlePropertyChanged(ref _stopwatchState, value); }
         }
 
         private async Task ClockForwardAnimation()
@@ -98,16 +103,8 @@ namespace Countdown.ViewModels
             }
         }
 
-
-
-
-        public StopwatchController()
-        {
-            StartStopTimerCommand = new RelayCommand(ExecuteTimer);
-            _cts = new CancellationTokenSource();
-        }
-
-
+        // this method is re-entrant due to the await operator but will only
+        // ever be run on the UI thread
         private async void ExecuteTimer(object p)
         {
             switch (StopwatchState)
@@ -153,7 +150,6 @@ namespace Countdown.ViewModels
             }
         }
 
-        // avoids a code analysis CA1001 warning...
         public void Dispose()
         {
             _cts.Dispose();

--- a/Countdown/Views/ConundrumView.xaml
+++ b/Countdown/Views/ConundrumView.xaml
@@ -64,7 +64,7 @@
                 <ColumnDefinition Width="{StaticResource CommonTabPageLeftColumnWidth}"/>
             </Grid.ColumnDefinitions>
 
-            <local:Clock Grid.Row="0" Width="100" Ticks="{Binding StopwatchController.Ticks}" HorizontalAlignment="Left" Margin="80,10,0,5" />
+            <local:Clock Grid.Row="0" Width="100" Ticks="{Binding StopwatchController.Ticks, Mode=OneWay}" HorizontalAlignment="Left" Margin="80,10,0,5" />
 
             <GroupBox Grid.Row="1" Header="Letters" Margin="5">
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Margin="2,10,0,7">

--- a/Countdown/Views/LettersView.xaml
+++ b/Countdown/Views/LettersView.xaml
@@ -188,7 +188,7 @@
                 <ColumnDefinition Width="{StaticResource CommonTabPageLeftColumnWidth}"/>
             </Grid.ColumnDefinitions>
 
-            <local:Clock Grid.Row="0" Width="100" Ticks="{Binding StopwatchController.Ticks}" HorizontalAlignment="Left" Margin="80,10,0,5" />
+            <local:Clock Grid.Row="0" Width="100" Ticks="{Binding StopwatchController.Ticks, Mode=OneWay}" HorizontalAlignment="Left" Margin="80,10,0,5" />
             
             <GroupBox Grid.Row="1" Header="Letters" Margin="5">
 

--- a/Countdown/Views/NumbersView.xaml
+++ b/Countdown/Views/NumbersView.xaml
@@ -41,7 +41,7 @@
                 <ColumnDefinition Width="{StaticResource CommonTabPageLeftColumnWidth}" />
             </Grid.ColumnDefinitions>
 
-            <local:Clock Grid.Row="0" Width="100" Ticks="{Binding StopwatchController.Ticks}" HorizontalAlignment="Left" Margin="80,10,0,5" />
+            <local:Clock Grid.Row="0" Width="100" Ticks="{Binding StopwatchController.Ticks, Mode=OneWay}" HorizontalAlignment="Left" Margin="80,10,0,5" />
 
             <GroupBox Grid.Row="1" Header="Tiles" Margin="5">
                 <AdornerDecorator>

--- a/Countdown/Views/StopwatchView.xaml
+++ b/Countdown/Views/StopwatchView.xaml
@@ -10,6 +10,6 @@
 
     <DockPanel LastChildFill="True" Margin="5,5,5,5">
         <Button Style="{StaticResource StartStopButtonStyle}" VerticalAlignment="Bottom"/>
-        <local:Clock Ticks="{Binding StopwatchController.Ticks}" />
+        <local:Clock Ticks="{Binding StopwatchController.Ticks, Mode=OneWay}" />
     </DockPanel>
 </UserControl>


### PR DESCRIPTION
Make the update rate 5ms.  After measuring it, this was the average update rate the system used when animating a double value that was previously used as the clock timer. Seems to result in less jitter.