### PR TITLE
Set next button text to install when required

### DIFF
--- a/Countdown/Installer/inno_script.iss
+++ b/Countdown/Installer/inno_script.iss
@@ -383,3 +383,12 @@ begin
   
   Result := ComparePackedVersion(X, Y) ;
 end;
+
+
+procedure CurPageChanged(CurPageID: Integer);
+begin
+  if CurPageID = wpSelectTasks then
+    WizardForm.NextButton.Caption := SetupMessage(msgButtonInstall)
+  else
+    WizardForm.NextButton.Caption := SetupMessage(msgButtonNext);
+end;


### PR DESCRIPTION
Now that the ready to install page is hidden.