### PR TITLE
Hold stream reference

### DIFF
--- a/Countdown/Views/AudioHelper.cs
+++ b/Countdown/Views/AudioHelper.cs
@@ -5,16 +5,16 @@ namespace Countdown.Views;
 internal class AudioHelper
 {
     private readonly MediaPlayer mediaPlayer = new MediaPlayer();
+    private readonly Stream? stream;
 
     public AudioHelper()
     {
-        Stream? stream = typeof(App).Assembly.GetManifestResourceStream("Countdown.Resources.audio.dat");
+        stream = typeof(App).Assembly.GetManifestResourceStream("Countdown.Resources.audio.dat");
 
         if (stream is not null)
         {
             mediaPlayer.SetStreamSource(stream.AsRandomAccessStream());
             mediaPlayer.Volume = Settings.Data.VolumePercentage / 100.0;
-
             Settings.Data.VolumeChanged += (s, a) => mediaPlayer.Volume = Settings.Data.VolumePercentage / 100.0;
         }
     }


### PR DESCRIPTION
Hold a reference to it otherwise it may be disposed of which will stop the audio playing.