### PR TITLE
omitting "EnableMsixTooling" breaks publishing

### DIFF
--- a/Countdown/Countdown.csproj
+++ b/Countdown/Countdown.csproj
@@ -8,7 +8,8 @@
     <Platforms>x86;x64;ARM64</Platforms>
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <PublishProfile>win-$(Platform).pubxml</PublishProfile>
-    <UseWinUI>true</UseWinUI>
+	<UseWinUI>true</UseWinUI>
+	<EnableMsixTooling>true</EnableMsixTooling>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <ApplicationIcon>Resources\app.ico</ApplicationIcon>


### PR DESCRIPTION
Even for unpackage builds. The normal retail/debug build works ok but the published build lacks xaml resources.