### PR TITLE
Defer setting first conundrum until view loaded

### DIFF
--- a/Countdown/ViewModels/ConundrumViewModel.cs
+++ b/Countdown/ViewModels/ConundrumViewModel.cs
@@ -24,8 +24,6 @@ internal sealed partial class ConundrumViewModel : PropertyChangedBase
 
         SolveCommand = new RelayCommand(ExecuteSolve, CanSolve);
         ChooseCommand = new RelayCommand(ExecuteChoose, CanChoose);
-
-        ExecuteChoose(null);
     }
 
     /// <summary>

--- a/Countdown/Views/ConundrumView.xaml.cs
+++ b/Countdown/Views/ConundrumView.xaml.cs
@@ -7,6 +7,14 @@ internal sealed partial class ConundrumView : Page
     public ConundrumView()
     {
         this.InitializeComponent();
+
+        Loaded += ConundrumView_Loaded;
+    }
+
+    private void ConundrumView_Loaded(object sender, RoutedEventArgs e)
+    {
+        Loaded -= ConundrumView_Loaded;
+        ViewModel?.ChooseCommand.Execute(null);
     }
 
     public ConundrumViewModel? ViewModel { get; set; }


### PR DESCRIPTION
Reduces the risk of the ui thread being blocked until the word list has finished being parsed